### PR TITLE
Use "TheTechRobo" instead of Ittussarom Ynohtna

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -172,7 +172,6 @@
 - [Imed Jaberi](https://github.com/3imed-jaberi/ama) - JavaScript dev, mentor, open source contributor, community builder, and speaker.
 - [Arpit Mohan](https://dev.to/mohanarpit/i-am-a-yc-alumnus-3x-vc-funded-founder-cto-ama-4006) - Distributed Systems Engineer, Java and Golang developer, 3x CTO, [blogger](https://blog.arpitmohan.com).
 - [TheTechRobo](https://github.com/thetechrobo/ama) - Hobbyist Python 3.x developer who corrects grammar so much he loses friends.
-- [Ittussarom Ynohtna](https://github.com/thetechrobo/ama) - Hobbyist Python 3.x developer who corrects grammar so much he loses friends.
 - [Lali Akhil Raj](https://github.com/Lalisfeed/ama) - Creating stuff for web & AI.
 - [Felipe Plets](https://github.com/felipeplets/ama) - Tech lead, open source contributor, and [blogger](https://plets.me).
 

--- a/readme.md
+++ b/readme.md
@@ -172,7 +172,7 @@
 - [Imed Jaberi](https://github.com/3imed-jaberi/ama) - JavaScript dev, mentor, open source contributor, community builder, and speaker.
 - [Arpit Mohan](https://dev.to/mohanarpit/i-am-a-yc-alumnus-3x-vc-funded-founder-cto-ama-4006) - Distributed Systems Engineer, Java and Golang developer, 3x CTO, [blogger](https://blog.arpitmohan.com).
 - [Yohix](https://github.com/yohix/ama) - iOS and web developer, open-source tool maker, loves coffee and music, he/him.
-- [Ittussarom Ynohtna](https://github.com/thetechrobo/ama) - Hobbyist Python 3.x developer who corrects grammar so much he loses friends.
+- [TheTechRobo](https://github.com/thetechrobo/ama) - Hobbyist Python 3.x developer who corrects grammar so much he loses friends.
 - [Lali Akhil Raj](https://github.com/Lalisfeed/ama) - Creating stuff for web & AI.
 - [Felipe Plets](https://github.com/felipeplets/ama) - Tech lead, open source contributor, and [blogger](https://plets.me).
 


### PR DESCRIPTION
Ittussarom Ynohtna was really a pseudonym so that I could use websites that required both first names and last names (such as Quora) without giving away my actual name, and I don't really use it anymore.